### PR TITLE
Clarify Salesforce integration options

### DIFF
--- a/appexchange/install.mdx
+++ b/appexchange/install.mdx
@@ -7,6 +7,10 @@ description: "Use the latest version (v1.8) of the Thnks Salesforce AppExchange 
   **Thnks Plan Level**: Thnks' Salesforce AppExchange integration is available for organizations on the Enterprise or Enterprise+ plan level. Contact [sales@thnks.com](mailto:sales@thnks.com) for information on how to upgrade.
 </Note>
 
+<Note>
+  **Integration Options**: This guide covers the AppExchange managed package. For custom API-based automation using Apex callouts (Process Builder, Flows, or Triggers), see our [API Integration Guide](/thnks_integrations/salesforce).
+</Note>
+
 ## System Requirements
 
 Below please find more information on the necessary requirements before installing our Salesforce App in your instance of Salesforce.

--- a/appexchange/overview.mdx
+++ b/appexchange/overview.mdx
@@ -3,6 +3,10 @@ title: "Overview"
 description: "Use the latest version (v1.8) of the Thnks Salesforce AppExchange app to capture all of your company's Thnks activity and send Thnks directly from within Salesforce. The app provides comprehensive integration between Thnks and Salesforce Leads, Contacts, Accounts and Opportunities."
 ---
 
+<Note>
+  **Looking for API Integration?** If you want to build custom Apex-based automation using the Thnks API directly, see our [API Integration Guide](/thnks_integrations/salesforce). This guide covers the AppExchange managed package approach.
+</Note>
+
 The custom Thnks objects allow you to build more robust reporting and understand your ROI by pulling detailed reports on user activity and messaging effectiveness.
 
 ## What's New in v1.8

--- a/appexchange/overview.mdx
+++ b/appexchange/overview.mdx
@@ -39,9 +39,14 @@ The custom Thnks objects allow you to build more robust reporting and understand
 
 ## Integration Overview
 
-Thnks has partnered with Salesforce to provide our clients with an application built specifically for Salesforce and available on the AppExchange. Version 1.8 introduces **bidirectional functionality**, allowing you to both:
+Thnks offers two ways to integrate with Salesforce:
 
-- **Send Thnks from Salesforce** → Initiate Thnks directly from Salesforce records
+1. **AppExchange App (This Guide)** - A managed package with pre-built UI components, automated data sync, and embedded Thnks interface
+2. **API Integration** - Custom Apex code using Thnks API for advanced automation scenarios ([see API guide](/thnks_integrations/salesforce))
+
+The AppExchange app (v1.8) provides **bidirectional functionality**, allowing you to both:
+
+- **Send Thnks from Salesforce** → Initiate Thnks directly from Salesforce records using embedded interface
 - **Receive Thnks data in Salesforce** → Capture all Thnks activity from web, mobile, and extension usage
 
 ## What Does It Do?

--- a/appexchange/quick_install.mdx
+++ b/appexchange/quick_install.mdx
@@ -3,6 +3,10 @@ title: "Quick Install"
 description: "Get up and running with Thnks v1.8 in minutes. This streamlined guide covers the essential steps for new installations."
 ---
 
+<Note>
+  **Choosing Your Integration Approach**: This guide covers the AppExchange managed package installation. For custom API-based automation using Apex callouts, see our [API Integration Guide](/thnks_integrations/salesforce).
+</Note>
+
 ## Prerequisites
 
 Before starting, ensure you have:


### PR DESCRIPTION
Added cross-references between the AppExchange managed package documentation and the API integration guide to help users understand the two distinct Salesforce integration approaches. This prevents confusion by clearly distinguishing the pre-built AppExchange app from custom API-based automation.

**Files changed:**
- `appexchange/overview.mdx` - Added notes distinguishing AppExchange app from API integration
- `appexchange/quick_install.mdx` - Added note directing users to API guide for custom automation
- `appexchange/install.mdx` - Added note clarifying the two integration options